### PR TITLE
メモリの使用率もオートスケーリングに追加

### DIFF
--- a/ecs_cloudwatch_logs/modules/web_app/auto_scaling.tf
+++ b/ecs_cloudwatch_logs/modules/web_app/auto_scaling.tf
@@ -31,14 +31,14 @@ resource "aws_appautoscaling_policy" "app-cpu-scale-up" {
 
 resource "aws_appautoscaling_policy" "app-memory-scaleup" {
   name = "memory-scale-up"
-  # CPU使用率をターゲットにしてターゲット追跡ポリシーで構築
+  # メモリ使用率をターゲットにしてターゲット追跡ポリシーで構築
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.app.resource_id
   scalable_dimension = aws_appautoscaling_target.app.scalable_dimension
   service_namespace  = aws_appautoscaling_target.app.service_namespace
   target_tracking_scaling_policy_configuration {
 
-    # CPU使用率50%を基準にする
+    # メモリ使用率50%を基準にする
     target_value       = 50
     disable_scale_in   = false
     scale_in_cooldown  = 300

--- a/ecs_cloudwatch_logs/modules/web_app/auto_scaling.tf
+++ b/ecs_cloudwatch_logs/modules/web_app/auto_scaling.tf
@@ -7,14 +7,35 @@ resource "aws_appautoscaling_target" "app" {
   service_namespace  = "ecs"
 }
 
-resource "aws_appautoscaling_policy" "app" {
-  name = "scale-up"
+resource "aws_appautoscaling_policy" "app-cpu-scale-up" {
+  name = "cpu-scale-up"
   # CPU使用率をターゲットにしてターゲット追跡ポリシーで構築
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.app.resource_id
   scalable_dimension = aws_appautoscaling_target.app.scalable_dimension
   service_namespace  = aws_appautoscaling_target.app.service_namespace
 
+  target_tracking_scaling_policy_configuration {
+
+    target_value       = 50
+    disable_scale_in   = false
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+    # ターゲットにするメトリクス
+    predefined_metric_specification {
+      # https://docs.aws.amazon.com/ja_jp/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "app-memory-scaleup" {
+  name = "memory-scale-up"
+  # CPU使用率をターゲットにしてターゲット追跡ポリシーで構築
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.app.resource_id
+  scalable_dimension = aws_appautoscaling_target.app.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.app.service_namespace
   target_tracking_scaling_policy_configuration {
 
     # CPU使用率50%を基準にする
@@ -25,7 +46,7 @@ resource "aws_appautoscaling_policy" "app" {
     # ターゲットにするメトリクス
     predefined_metric_specification {
       # https://docs.aws.amazon.com/ja_jp/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
   }
 }


### PR DESCRIPTION
こちらのように、ECSタスクのCPU使用率が1分くらい継続して5%を超えると無事スケールアウトしてくれた

https://zenn.dev/bun913/scraps/402654b28cdd9b

Closes #70 